### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,10 +7,10 @@ on:
   push:
     branches:
       - 'feature*'
-      - 'feature/*'
       - 'feature_*'
-      - 'hotfix*'
+      - 'feature/*'
       - 'hotfix/*'
+      - 'hotfix*'
       - 'master'
   schedule:
     - cron: '0 4 * * *'
@@ -21,12 +21,12 @@ jobs:
   code_quality:
 
     name: SonarCloud Code Quality Check
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
 
     - name: Checkout source code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       with:
         path: 'darkwizard242.uget'
         fetch-depth: 0
@@ -34,6 +34,7 @@ jobs:
     - name: SonarCloud Scan
       uses: sonarsource/sonarcloud-github-action@master
       with:
+        projectBaseDir: 'darkwizard242.uget'
         args: >
           -Dsonar.projectVersion=${{ github.ref }}_${{ github.run_number }}
       env:
@@ -44,16 +45,16 @@ jobs:
   build:
 
     name: Build & Test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
-      max-parallel: 8
+      max-parallel: 6
       matrix:
-        IMAGE: [ubuntu-20.04, ubuntu-18.04, ubuntu-16.04, centos-7, debian-buster, debian-stretch]
+        IMAGE: [ubuntu-20.04, ubuntu-18.04, centos-7, debian-buster, debian-stretch]
 
     steps:
 
     - name: Checkout source code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       with:
         path: 'darkwizard242.uget'
 
@@ -69,6 +70,7 @@ jobs:
         pip3 install -U pip wheel ansible molecule[docker] docker ansible-lint flake8 pytest-testinfra
 
     - name: Execute Molecule test of role for ${{ matrix.IMAGE }}
+      working-directory: 'darkwizard242.uget'
       run: DISTRO=${{ matrix.IMAGE }} molecule test
       env:
         PY_COLORS: '1'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,14 +10,14 @@ jobs:
   release:
 
     name: Release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
 
     - name: Checkout source code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       with:
-        path: 'darkwizard242.unzip'
+        path: 'darkwizard242.uget'
 
     - name: Set up Python 3.10.0
       uses: actions/setup-python@v2
@@ -31,4 +31,5 @@ jobs:
         pip3 install -U pip wheel ansible
 
     - name: Import to Ansible Galaxy.
+      working-directory: 'darkwizard242.uget'
       run: ansible-galaxy role import --api-key ${{ secrets.GALAXY_API_KEY }} ${{ github.repository_owner }} $(echo ${{ github.repository }} | sed 's/.*\///')

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Ali Muhammad
+Copyright (c) 2022 Ali Muhammad
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,7 +10,6 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - xenial
         - bionic
         - focal
     - name: Debian

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -3,3 +3,5 @@
   hosts: all
   roles:
     - role: darkwizard242.uget
+  vars:
+    ansible_python_interpreter: /usr/bin/python3

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -8,8 +8,8 @@ lint: |
     ansible-lint
     flake8
 platforms:
-  - name: ${DISTRO:-ubuntu-18.04}
-    image: "darkwizard242/ansible:${DISTRO:-ubuntu-18.04}"
+  - name: ${DISTRO:-ubuntu-20.04}
+    image: "darkwizard242/ansible:${DISTRO:-ubuntu-20.04}"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     pre_build_image: true

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,8 +2,8 @@ sonar.projectKey=ansible-role-uget
 sonar.organization=tech-overlord-github
 sonar.projectName=ansible-role-uget
 sonar.coverage.exclusions=**/**
-#sonar.projectVersion=$TRAVIS_JOB_ID
 sonar.python.version=3
+#sonar.projectVersion=$TRAVIS_JOB_ID
 
 # =====================================================
 #   Meta-data for the project


### PR DESCRIPTION
- Bump container image in molecule config to ubuntu 20.04
- Update `build-and-test`, `release` github action workflows.
- Define `sonar.python.version=3` in sonarcloud config
- Remove Ubuntu 16.04 as supported os from role's metadata due to being EOL